### PR TITLE
Add README workflow description and annotate config defaults

### DIFF
--- a/E-mail trend.py
+++ b/E-mail trend.py
@@ -44,16 +44,28 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FILENAME = "email_trend_config.json"
 CONFIG_PATH = os.path.join(SCRIPT_DIR, CONFIG_FILENAME)
 
+# Domyślne wartości używane przy generowaniu pliku konfiguracyjnego.
+# Każdy klucz można nadpisać w `email_trend_config.json`.
 DEFAULT_CONFIG = {
+    # Identyfikator aplikacji (Client ID) zarejestrowanej w Entra ID.
     "client_id": "",
+    # Identyfikator dzierżawy (Tenant ID), w której zarejestrowana jest aplikacja.
     "tenant_id": "",
+    # Sekret klienta (Client Secret) używany do uwierzytelnienia aplikacji.
     "client_secret": "",
+    # Lista zakresów uprawnień przekazywana do Microsoft Graph.
     "scopes": ["https://graph.microsoft.com/.default"],
+    # Lokalizacja i nazwa pliku logów.
     "log_filename": "email_trend_app_only.log",
+    # Poziom szczegółowości logów (np. DEBUG, INFO, WARNING).
     "log_level": "INFO",
+    # Limit czasu na pobranie danych pojedynczego żądania w sekundach.
     "fetch_timeout_seconds": 30,
+    # Opóźnienie między ponownymi próbami w sekundach po wystąpieniu błędu.
     "retry_delay_seconds": 5,
+    # Dodatkowe opóźnienie między kolejnymi żądaniami w sekundach (throttling).
     "throttle_delay_seconds": 1,
+    # Maksymalna liczba równoległych żądań wysyłanych do Graph API.
     "semaphore_limit": 7,
 }
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Skrypt automatycznie sprawdza obecność pliku `email_trend_config.json` w tym s
 }
 ```
 
+## Jak działa skrypt
+
+1. **Kontrola środowiska** – przy pierwszym uruchomieniu skrypt sprawdza, czy wymagane moduły (`requests`, `msal`, `openpyxl`, `tqdm`, `aiohttp`) są dostępne. Brakujące biblioteki są instalowane automatycznie, a skrypt wznawia działanie po zakończeniu instalacji.
+2. **Ładowanie konfiguracji** – plik `email_trend_config.json` jest wczytywany i walidowany. Brakujące klucze są dopisywane z wartościami domyślnymi, a nieprawidłowe wartości (np. ujemne limity czasowe) są zastępowane bezpiecznymi ustawieniami.
+3. **Uwierzytelnianie** – na podstawie `client_id`, `tenant_id`, `client_secret` i listy `scopes` tworzony jest klient MSAL, który pobiera token dostępu aplikacji (tryb app-only) do Microsoft Graph.
+4. **Pobieranie skrzynek** – po podaniu adresów e-mail skrypt równolegle przetwarza każdą skrzynkę. Dla każdej skrzynki rekurencyjnie pobiera strukturę folderów, korzystając z ograniczeń `semaphore_limit` oraz opóźnień `throttle_delay_seconds`, aby nie przeciążać API.
+5. **Pobieranie wiadomości** – z każdego folderu pobierane są wiadomości wraz z nagłówkami, rozmiarem ciała i załączników. Skrypt potrafi oszacować rozmiar wiadomości nawet wtedy, gdy Graph nie zwraca wszystkich danych, np. na podstawie nagłówków i podglądu treści.
+6. **Obsługa błędów** – operacje sieciowe mają wbudowane ponawianie (`retry_delay_seconds`) i limit czasu (`fetch_timeout_seconds`). Każda nieudana próba jest logowana, a skrócone komunikaty błędów pozwalają szybko znaleźć przyczynę problemu.
+7. **Eksport do Excela** – po zebraniu wszystkich wiadomości dane zapisywane są do pliku `.xlsx`. Powstaje osobna karta dla każdego folderu (z listą wiadomości i rozmiarami) oraz karta `Podsumowanie`, która agreguje liczbę wiadomości i łączny rozmiar miesięcznie dla każdego folderu.
+8. **Informacje pomocnicze** – pasek postępu (`tqdm`) pokazuje liczbę przetworzonych wiadomości, a logi zapisywane są zarówno do pliku jak i na standardowe wyjście, co ułatwia nadzór nad działaniem narzędzia.
+
 ### Logowanie
 
 * Logi są zapisywane do pliku wskazanego w `log_filename` (domyślnie `email_trend_app_only.log` w katalogu skryptu) oraz wypisywane na standardowe wyjście.


### PR DESCRIPTION
## Summary
- add inline comments that document each default configuration setting in the script
- extend the README with a new section describing the script workflow and error-handling features

## Testing
- python -m compileall 'E-mail trend.py'

------
https://chatgpt.com/codex/tasks/task_e_68cd16ff9e94832081202253b72814a7